### PR TITLE
Make Cloudflare preview builds self-contained

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -23,12 +23,14 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
             # Temporary: master's deploy-preview.yml expects the
-            # <root>/web/.svelte-kit/cloudflare layout. Drop this step and
-            # flatten the deploy directory path when this PR merges.
+            # <root>/web/.svelte-kit layout (wrangler resolves _worker.js's
+            # ../output and ../cloudflare-tmp imports at deploy time). Drop
+            # this step at merge and upload web/.svelte-kit directly, pointing
+            # the deploy directory at <download-path>/cloudflare.
             - name: "prepare build artifact"
               run: |
-                  mkdir -p preview-artifact/web/.svelte-kit
-                  cp -a web/.svelte-kit/cloudflare preview-artifact/web/.svelte-kit/
+                  mkdir -p preview-artifact/web
+                  cp -a web/.svelte-kit preview-artifact/web/
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -22,13 +22,9 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
-            - name: "prepare build artifact"
-              run: |
-                  mkdir -p preview-artifact/web
-                  cp -a web/.svelte-kit preview-artifact/web/
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:
                   name: "preview-build"
-                  path: preview-artifact
+                  path: "web/.svelte-kit"
                   include-hidden-files: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -20,16 +20,11 @@ jobs:
               with:
                   node-version: "24"
                   cache: "pnpm"
-            # The deployment workflow receives this dependency tree as an artifact. Use a physical,
-            # npm-compatible layout instead of pnpm's symlinked virtual store so Wrangler can bundle the worker.
-            - run: pnpm install --frozen-lockfile --config.node-linker=hoisted
+            - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:
                   name: "preview-build"
-                  path: |
-                    node_modules
-                    web/.svelte-kit
-                    web/node_modules
+                  path: web/.svelte-kit
                   include-hidden-files: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -22,8 +22,15 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
+            # Temporary: master's deploy-preview.yml expects the
+            # <root>/web/.svelte-kit/cloudflare layout. Drop this step and
+            # flatten the deploy directory path when this PR merges.
+            - name: "prepare build artifact"
+              run: |
+                  mkdir -p preview-artifact/web/.svelte-kit
+                  cp -a web/.svelte-kit/cloudflare preview-artifact/web/.svelte-kit/
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:
                   name: "preview-build"
-                  path: "web/.svelte-kit/cloudflare"
+                  path: preview-artifact

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -34,3 +34,4 @@ jobs:
               with:
                   name: "preview-build"
                   path: preview-artifact
+                  include-hidden-files: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -20,7 +20,9 @@ jobs:
               with:
                   node-version: "24"
                   cache: "pnpm"
-            - run: pnpm install
+            # The deployment workflow receives this dependency tree as an artifact. Use a physical,
+            # npm-compatible layout instead of pnpm's symlinked virtual store so Wrangler can bundle the worker.
+            - run: pnpm install --frozen-lockfile --config.node-linker=hoisted
             - run: pnpm --filter=web run build
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -22,11 +22,6 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
-            # Temporary: master's deploy-preview.yml expects the
-            # <root>/web/.svelte-kit layout (wrangler resolves _worker.js's
-            # ../output and ../cloudflare-tmp imports at deploy time). Drop
-            # this step at merge and upload web/.svelte-kit directly, pointing
-            # the deploy directory at <download-path>/cloudflare.
             - name: "prepare build artifact"
               run: |
                   mkdir -p preview-artifact/web

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -22,9 +22,13 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
+            - name: "prepare build artifact"
+              run: |
+                  mkdir -p preview-artifact/web
+                  cp -a web/.svelte-kit preview-artifact/web/
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:
                   name: "preview-build"
-                  path: web/.svelte-kit
+                  path: preview-artifact
                   include-hidden-files: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -22,13 +22,8 @@ jobs:
                   cache: "pnpm"
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter=web run build
-            - name: "prepare build artifact"
-              run: |
-                  mkdir -p preview-artifact/web
-                  cp -a web/.svelte-kit preview-artifact/web/
             - name: "upload build artifact"
               uses: "actions/upload-artifact@v7"
               with:
                   name: "preview-build"
-                  path: preview-artifact
-                  include-hidden-files: true
+                  path: "web/.svelte-kit/cloudflare"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,4 +34,7 @@ jobs:
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
                   directory: ${{ steps.preview-build-artifact.outputs.download-path }}
+                  # refined-cf-pages-action defaults to wrangler 3; adapter-cloudflare
+                  # requires wrangler 4
+                  wranglerVersion: "4"
                   deploymentName: Preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -35,3 +35,4 @@ jobs:
                   projectName: "diffs"
                   directory: ${{ steps.preview-build-artifact.outputs.download-path }}/web/.svelte-kit/cloudflare
                   deploymentName: Preview
+                  wranglerVersion: "4"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,6 +18,8 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         name: "Deploy Preview to Cloudflare Pages"
         steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v6"
             - name: "Download build artifact"
               uses: "actions/download-artifact@v7"
               id: "preview-build-artifact"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,6 +33,5 @@ jobs:
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
-                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}/web/.svelte-kit/cloudflare
+                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}
                   deploymentName: Preview
-                  wranglerVersion: "4"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,8 +33,7 @@ jobs:
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
-                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}
-                  # refined-cf-pages-action defaults to wrangler 3; adapter-cloudflare
-                  # requires wrangler 4
+                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare
+                  workingDirectory: "web"
                   wranglerVersion: "4"
                   deploymentName: Preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,8 +18,6 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         name: "Deploy Preview to Cloudflare Pages"
         steps:
-            - name: "Checkout"
-              uses: "actions/checkout@v6"
             - name: "Download build artifact"
               uses: "actions/download-artifact@v7"
               id: "preview-build-artifact"
@@ -36,6 +34,5 @@ jobs:
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
                   directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare
-                  workingDirectory: "web"
                   wranglerVersion: "4"
                   deploymentName: Preview

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
-                  directory: ".svelte-kit/cloudflare"
-                  workingDirectory: "web"
+                  directory: "web/.svelte-kit/cloudflare"
                   wranglerVersion: "4"
                   deploymentName: Production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
                   projectName: "diffs"
-                  directory: "web/.svelte-kit/cloudflare"
+                  directory: ".svelte-kit/cloudflare"
+                  workingDirectory: "web"
                   wranglerVersion: "4"
                   deploymentName: Production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,37 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  push:
-    branches: ["master"]
+    push:
+        branches: ["master"]
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    name: Build and deploy
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: "24"
-          cache: "pnpm"
-      - name: Install frontend dependencies
-        run: pnpm install
-      - name: Build frontend
-        run: pnpm --filter=web run build
-        env:
-          GITHUB_CLIENT_SECRET: ${{ secrets.VITE_GITHUB_CLIENT_SECRET }}
-      - name: "Deploy to Cloudflare Pages"
-        uses: "AdrianGonz97/refined-cf-pages-action@v1"
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: "diffs"
-          directory: "web/.svelte-kit/cloudflare"
-          deploymentName: Production
+    deploy:
+        runs-on: ubuntu-latest
+        name: Build and deploy
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v6
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v6
+            - name: Setup Node
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "24"
+                  cache: "pnpm"
+            - name: Install frontend dependencies
+              run: pnpm install
+            - name: Build frontend
+              run: pnpm --filter=web run build
+              env:
+                  GITHUB_CLIENT_SECRET: ${{ secrets.VITE_GITHUB_CLIENT_SECRET }}
+            - name: "Deploy to Cloudflare Pages"
+              uses: "AdrianGonz97/refined-cf-pages-action@v1"
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  projectName: "diffs"
+                  directory: ".svelte-kit/cloudflare"
+                  workingDirectory: "web"
+                  wranglerVersion: "4"
+                  deploymentName: Production

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,9 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(() => ({
     plugins: [tailwindcss(), sveltekit()],
-    // Bundle the server-side deps into the SSR output so the adapter-cloudflare
-    // artifact is self-contained (it ships no node_modules).
-    ssr: { noExternal: ["@sveltejs/kit", "diff", "shiki"] },
+    ssr: { noExternal: ["@sveltejs/kit", "chroma-js", "diff", "shiki"] },
     // Tell Vitest to use the `browser` entry points in `package.json` files, even though it's running in Node
     resolve: process.env.VITEST
         ? {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,9 +4,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(() => ({
     plugins: [tailwindcss(), sveltekit()],
-    ssr: {
-        noExternal: true as const,
-    },
+    // Bundle the server-side deps into the SSR output so the adapter-cloudflare
+    // artifact is self-contained (it ships no node_modules).
+    ssr: { noExternal: ["@sveltejs/kit", "diff", "shiki"] },
     // Tell Vitest to use the `browser` entry points in `package.json` files, even though it's running in Node
     resolve: process.env.VITEST
         ? {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(() => ({
     plugins: [tailwindcss(), sveltekit()],
+    ssr: {
+        noExternal: true as const,
+    },
     // Tell Vitest to use the `browser` entry points in `package.json` files, even though it's running in Node
     resolve: process.env.VITEST
         ? {

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+    "name": "diffs",
+    "pages_build_output_dir": "./.svelte-kit/cloudflare",
+    "compatibility_date": "2026-09-07",
+    "compatibility_flags": ["nodejs_compat"],
+}


### PR DESCRIPTION
## Summary

Cloudflare/SvelteKit preview builds previously uploaded the full pnpm dependency tree because `adapter-cloudflare` ships Vite's SSR output as-is, and `wrangler pages deploy` bundles the worker at deploy time against whatever is on disk. That produced artifacts in the 600–870 MB range.

This PR makes the build output self-contained:

- `ssr.noExternal` in `web/vite.config.ts` bundles the packages that Vite leaves external in the SSR output (`@sveltejs/kit`, `chroma-js`, `diff`, `shiki` — verified by inspecting the built server chunks across all import forms). The only remaining external imports are `node:async_hooks`/`node:crypto` (Workers runtime) and `cloudflare:workers`
- adds `web/wrangler.jsonc` (project name, `pages_build_output_dir`, `compatibility_date: 2026-09-07`, `nodejs_compat` — SvelteKit's server output imports `node:async_hooks`). The production deploy picks this up via `workingDirectory: web`; verified with `wrangler pages download config` that the project has no dashboard-only settings that could be clobbered, and with wrangler debug logs that the config is detected from that cwd
- both deploy workflows pin `wranglerVersion: "4"` (the refined action defaults to wrangler 3)
- preview artifact shrinks from 600–870 MB to ~6 MB compressed (full `.svelte-kit`, no `node_modules`); the preview deploy job remains unprivileged — no PR source checkout, no dependency install

## Results

- Build and preview deploy green in CI (run 34084516357, before the final artifact simplification)
- `pnpm --dir web run check` passes with the existing two warnings
- Vitest, lint, and formatting checks pass

## Note

Preview deploys from this branch fail until the PR merges: `workflow_run` jobs execute master's `deploy-preview.yml`, which still expects the old artifact layout. After merge both sides line up (`download-path/cloudflare`). Preview deploys intentionally do not pick up `wrangler.jsonc` (no checkout in the deploy job); only production does.